### PR TITLE
Disabling map generation

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,3 @@
 REACT_APP_API = 'https://safers-gateway.herokuapp.com'
+# When set to false, source maps are not generated for a production build. This solves out of memory (OOM) issues on some smaller machines. 
+GENERATE_SOURCEMAP=false 


### PR DESCRIPTION
Because of the memory issue of the server, map generation is turned off. This must be turned on for production server when the memory is increased.