### PR TITLE
added tenant-id to oauth2 calls

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,5 +5,5 @@ export const BASE_URL = process.env.REACT_APP_API ? process.env.REACT_APP_API : 
 export const CLIENT_BASE_URL = process.env.REACT_APP_CLIENT_BASE_URL ? process.env.REACT_APP_CLIENT_BASE_URL : 'http://localhost:3000'
 export const AUTH_BASE_URL = process.env.REACT_APP_AUTH_BASE_URL ? process.env.REACT_APP_AUTH_BASE_URL : 'http://localhost:9011'
 export const AUTH_CLIENT_ID  = process.env.REACT_APP_AUTH_CLIENT_ID ? process.env.REACT_APP_AUTH_CLIENT_ID  : '24c3750b-088a-43d0-af23-781258e6e78c'
+export const AUTH_TENANT_ID  = process.env.REACT_APP_AUTH_TENANT_ID ? process.env.REACT_APP_AUTH_TENANT_ID  : null
 export const REDIRECT_URL =  process.env.REACT_APP_REDIRECT_URL ? process.env.REACT_APP_REDIRECT_URL  : 'auth/sign-in'
-

--- a/src/pages/Authentication/OAuth2.js
+++ b/src/pages/Authentication/OAuth2.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Button } from 'reactstrap';
 import { useLocation } from 'react-router-dom';
 import { generalInProgress, signInOauth2 } from '../../store/appAction';
-import { AUTH_BASE_URL, CLIENT_BASE_URL, AUTH_CLIENT_ID, REDIRECT_URL  } from '../../config'
+import { AUTH_BASE_URL, CLIENT_BASE_URL, AUTH_CLIENT_ID, AUTH_TENANT_ID, REDIRECT_URL  } from '../../config'
 
 
 /* 
@@ -27,7 +27,7 @@ const OAuth2 = () => {
       client_id: AUTH_CLIENT_ID,
       redirect_uri: `${CLIENT_BASE_URL}/${REDIRECT_URL}`,
       locale: 'en',
-      // tenant_id: 'whatever',
+      tenant_id: AUTH_TENANT_ID,
       // state: 'whatever',
       scope: 'offline_access',
     };


### PR DESCRIPTION
Using the safers FusionAuth server requires some more credentials to successfully request the authorization code.  Those have been added to the `config.js` file and the function in `OAuth2.js` that requests the code.