### PR TITLE
Ensured that access_token in session when logging in via oauth2

### DIFF
--- a/src/store/authentication/action.js
+++ b/src/store/authentication/action.js
@@ -40,7 +40,7 @@ export const signInOauth2 = ({authCode}) => async (dispatch) => {
   const content = response.data;
   dispatch(InProgress(false));
   if (response.status === 200) {
-    return setSessionData(content.token, null, content.user, dispatch)
+    return setSessionData(content.access_token, null, content.user, dispatch)
   }
   return dispatch(signInFail(content.detail));
 }


### PR DESCRIPTION
The response when logging in via oauth2 is exactly the same as when logging in locally, so the session data should be the
same too.  The `access_token` is required in order to authenticate most requests to the API.