### PR TITLE
feat(frontend): ensured validating an alert gives feedback

### DIFF
--- a/src/store/alerts/action.js
+++ b/src/store/alerts/action.js
@@ -79,8 +79,8 @@ const setFavoriteAlertFail = (error) => {
 
 export const validateAlert = (alertId) => async (dispatch) => {
   const response = await api.post(endpoints.fireAlerts.validate.replace(':alert_id', alertId), { type: 'VALIDATED' });
-  if (response.status === 200) {
-    const successMessage = response.data['detail']    
+  if (response.status === 200 || response.status === 201) {
+    const successMessage = response.data['detail']  
     return dispatch(validateAlertSuccess(successMessage));
   }
   else


### PR DESCRIPTION
Validating an alert can either return a 201 (created a new event) or a 200 (added to an existing event); the code that checked to see if a notification should be displayed was only checking for 200.