### PR TITLE
feat(backend): order of camera_media queries was reversed

### DIFF
--- a/src/pages/In-situ/Components/SortSection.js
+++ b/src/pages/In-situ/Components/SortSection.js
@@ -105,8 +105,8 @@ const SortSection = ({t, checkedStatus, setCheckedStatus}) => {
             onChange={(e) => filterByDate(e.target.value)}
             value={sortByDate}
           >
-            <option value={'date'} >{t('Sort By')} : {t('Date')} desc</option>
-            <option value={'-date'} >{t('Sort By')} : {t('Date')} asc</option>
+            <option value={'-date'} >{t('Sort By')} : {t('Date')} desc</option>
+            <option value={'date'} >{t('Sort By')} : {t('Date')} asc</option>
           </Input>
         </Col>
         <Col xl={4} className='my-1'>

--- a/src/store/insitu/reducer.js
+++ b/src/store/insitu/reducer.js
@@ -12,7 +12,7 @@ const initialState = {
   iconLayer: undefined,
   alertId : null,
   hoverInfo: undefined,
-  sortByDate: 'date',
+  sortByDate: '-date',
   alertSource: '',
   dateRange : getDefaultDateRange(),
   currentPage: 1,


### PR DESCRIPTION
Swapped values for ascending/descending options in SortSection component.  And made "descending" the default value.

jira issue: https://astrosat.atlassian.net/browse/SAFB-178