### PR TITLE
fix(frontend): Fix date font size in events to match elsewhere

### DIFF
--- a/src/assets/scss/custom/pages/_alerts.scss
+++ b/src/assets/scss/custom/pages/_alerts.scss
@@ -44,9 +44,6 @@
     line-height: 1.43;
     letter-spacing: 0.01px;
     color: #d8d8d8;
-    &.date {
-      font-size: 0.6375rem;
-    }
   }
   .alert-source-text {
     font-size: 0.7375rem;


### PR DESCRIPTION
Took out card-specific font size, should be 0.737rem
like elsewhere

IssueID SAFB-180