### PR TITLE
SAFB-194: Create On-Demand Data Layers Dialog

### DIFF
--- a/src/assets/scss/custom/components/_buttons.scss
+++ b/src/assets/scss/custom/components/_buttons.scss
@@ -95,7 +95,7 @@ a {
 }
 
 .btn-orange.request-map {
-  background-color: #fc9432ff ;
+  background-color: $orange ;
   color: black !important;
   margin-bottom: 1rem;
 }
@@ -108,7 +108,7 @@ a {
   font-size: 1rem;
   border: none;
   &:hover {
-    background-color: #fc9432ff;
+    background-color: $orange;
   }
 }
 
@@ -117,8 +117,8 @@ a {
   border-radius: 5px;
   border: 1px solid transparent;
   &:hover {
-    border: 1px solid #e27b1d;
-    color: #e27b1d;
+    border: 1px solid $orange;
+    color: $orange;
   }
 }
 

--- a/src/pages/DataLayer/OnDemandDataLayer.js
+++ b/src/pages/DataLayer/OnDemandDataLayer.js
@@ -20,7 +20,7 @@ import SimpleBar from 'simplebar-react';
 import MOCKDATA from './mockdata';
 
 const SLIDER_SPEED = 800;
-const OnDemandDataLayer = ({ t, setActiveTab }) => {
+const OnDemandDataLayer = ({ t, setActiveTab, dataLayerPanels }) => {
   const defaultAoi = useSelector(state => state.user.defaultAoi);
   const dateRange = useSelector(state => state.common.dateRange)
   //const dataLayers = useSelector(state => state.dataLayer.dataLayers);
@@ -235,35 +235,35 @@ const OnDemandDataLayer = ({ t, setActiveTab }) => {
           style={{ maxWidth: '50rem' }}
         >
           <div className='d-flex flex-column align-items-center p-5'>
-            <h2>Select Data Type</h2>
+            <h2>{t('Select Data Type')}</h2>
             <div className='d-flex flex-nowrap gap-5 my-5'>
               <button
-                value={2} 
+                value={dataLayerPanels.FIRE_AND_BURNED_AREA} 
                 onClick={handleDialogButtonClick}
                 className='data-layers-dialog-btn'
               >
-                 Fire and Burned Area
+                {t('Fire and Burned Area')}
               </button>
               <button 
-                value={3} 
+                value={dataLayerPanels.POST_EVENT_MONITORING} 
                 onClick={handleDialogButtonClick}
                 className='data-layers-dialog-btn'
               >
-                  Post Event Monitoring
+                {t('Post Event Monitoring')}
               </button>
               <button
-                value={4} 
+                value={dataLayerPanels.WILDfIRE_SIMULATION} 
                 onClick={handleDialogButtonClick}
                 className='data-layers-dialog-btn'
               >
-                  Wildfire Simulation
+                {t('Wildfire Simulation')}
               </button>
             </div>
             <button 
               onClick={toggleModal}
               className='data-layers-dialog-cancel'
             >
-              Cancel
+              {t('Cancel')}
             </button>
           </div>
         </Modal>
@@ -275,7 +275,7 @@ const OnDemandDataLayer = ({ t, setActiveTab }) => {
                   <Button 
                     className="request-map btn-orange" 
                     onClick={toggleModal}>
-                      Request a map
+                    {t('Request a map')}
                   </Button>
                 </div>
               </Col>
@@ -390,7 +390,8 @@ const OnDemandDataLayer = ({ t, setActiveTab }) => {
 
 OnDemandDataLayer.propTypes = {
   t: PropTypes.any,
-  setActiveTab: PropTypes.func
+  setActiveTab: PropTypes.func,
+  dataLayerPanels: PropTypes.object,
 }
 
 export default withTranslation(['common'])(OnDemandDataLayer);

--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -1,18 +1,27 @@
 import React, { useState } from 'react';
 import { Nav, Row, Col, NavItem, NavLink, TabPane, TabContent } from 'reactstrap';
+import { useTranslation } from 'react-i18next';
 import DataLayer from './DataLayer';
 import OnDemandDataLayer from './OnDemandDataLayer';
 
+const dataLayerPanels = {
+  DATA_LAYER: 0,
+  ON_DEMAND_DATA_LAYER: 1,
+  FIRE_AND_BURNED_AREA:2,
+  POST_EVENT_MONITORING: 3,
+  WILDfIRE_SIMULATION: 4,
+}
+
 const DataLayerDashboard = () => {
-  const [activeTab, setActiveTab] = useState(0);
-  
+  const { t } = useTranslation();
+  const [activeTab, setActiveTab] = useState(dataLayerPanels.DATA_LAYER);
   return(
     <div className='page-content'>
       <div className='mx-2 sign-up-aoi-map-bg'>
         <Row>
           <Col xl={5} className='mb-3'>
             <Row>
-              <Col xl={4}><h4>Data Layers</h4></Col>
+              <Col xl={4}><h4>{t('Data Layers')}</h4></Col>
               <Col xl={8}>
                 <Nav className='d-flex flex-nowrap' pills fill>
                   <NavItem>
@@ -20,7 +29,7 @@ const DataLayerDashboard = () => {
                       className={{'active': activeTab===0}}
                       onClick={()=>setActiveTab(0)}
                     >
-                Operational Map Layers
+                      {t('Operational Map Layers')}
                     </NavLink>
                   </NavItem>
                   <NavItem>
@@ -28,7 +37,7 @@ const DataLayerDashboard = () => {
                       className={{'active': activeTab===1}}
                       onClick={()=>setActiveTab(1)}
                     >
-                On-Demand Map Layers
+                      {t('On-Demand Map Layers')}
                     </NavLink>
                   </NavItem>
                 </Nav>
@@ -38,19 +47,23 @@ const DataLayerDashboard = () => {
           <Col xl={7}/>
         </Row>
         <TabContent activeTab={activeTab}>
-          <TabPane tabId={0}>
-            <DataLayer />
+          <TabPane tabId={dataLayerPanels.DATA_LAYER}>
+            <DataLayer t={t} />
           </TabPane>
-          <TabPane tabId={1}>
-            <OnDemandDataLayer setActiveTab={setActiveTab} />
+          <TabPane tabId={dataLayerPanels.ON_DEMAND_DATA_LAYER}>
+            <OnDemandDataLayer
+              t={t}
+              setActiveTab={setActiveTab} 
+              dataLayerPanels={dataLayerPanels}  
+            />
           </TabPane>
-          <TabPane tabId={2}>
+          <TabPane tabId={dataLayerPanels.FIRE_AND_BURNED_AREA}>
             <div>Fire and Burned Area form.</div>
           </TabPane>
-          <TabPane tabId={3}>
+          <TabPane tabId={dataLayerPanels.POST_EVENT_MONITORING}>
             <div>Post Event Monitoring</div>
           </TabPane>
-          <TabPane tabId={4}>
+          <TabPane tabId={dataLayerPanels.WILDfIRE_SIMULATION}>
             <div>Wildfire Simulation</div>
           </TabPane>
         </TabContent>


### PR DESCRIPTION
Closes #SAFB-194

This creates the dialog for the On-Demand Data Layers tab, including functionality and styles, which allows
the various forms to be accessed inside the Data Layers panel.

I had a look around for buttons with similar styles to re-use, but couldn't find any, so made some new classes
to fit the designs.