### PR TITLE
fix(frontend): Style SSO login same as Sign Up button

### DIFF
--- a/src/pages/Authentication/OAuth2.js
+++ b/src/pages/Authentication/OAuth2.js
@@ -52,10 +52,13 @@ const OAuth2 = () => {
   return (
     <div className='text-center'>
       <Button
-        className="outh2-btn"
+        className="my-4 sign-in-btn"
         color="primary"
-        onClick={()=>{authorize()}}>
-        SSO Sign In
+        onClick={() => {
+          authorize();
+        }}
+      >
+        SSO SIGN IN
       </Button>
     </div>     
   );


### PR DESCRIPTION
I've made the button styling the same between the `SSO SIGN IN` and `SIGN UP` buttons. The styling was already there for the latter button, I just applied the same classes, to the former.