### PR TITLE
Make the fire forecast image size correctly

### DIFF
--- a/src/pages/DataLayer/constants.js
+++ b/src/pages/DataLayer/constants.js
@@ -7,3 +7,5 @@ export const DATA_LAYERS_PANELS = {
   postEventMonitoring: 3,
   wildfireSimulation: 4,
 }
+
+export const EUROPEAN_BBOX = [-18.369140, 14.519780, 41.660156, 71.130987]

--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { FlyToInterpolator } from 'deck.gl';
+import { FlyToInterpolator, COORDINATE_SYSTEM } from 'deck.gl';
 import { Nav, Row, Col, NavItem, NavLink, TabPane, TabContent } from 'reactstrap';
 import toastr from 'toastr';
 import { useTranslation } from 'react-i18next';
@@ -15,7 +15,7 @@ import PostEventMonitoringForm from './PostEventMonitoringForm'
 import WildfireSimulation from './WildfireSimulation'
 import { getAllDataLayers, setNewAlertState, setAlertApiParams } from '../../store/appAction';
 import { getBoundingBox } from '../../helpers/mapHelper';
-import { SLIDER_SPEED, DATA_LAYERS_PANELS } from './constants'
+import { SLIDER_SPEED, DATA_LAYERS_PANELS, EUROPEAN_BBOX } from './constants'
 import { filterNodesByProperty } from '../../store/utility';
 import { fetchEndpoint } from '../../helpers/apiHelper';
 import { setFilteredAlerts } from '../../store/alerts/action';
@@ -125,7 +125,7 @@ const DataLayerDashboard = () => {
       const urls = getUrls();
       const timestamps = getTimestamps();
       setTimestamp(timestamps[sliderValue])
-      const imageUrl = urls[0].replace('{bbox}', boundingBox);
+      const imageUrl = urls[0].replace('{bbox}', EUROPEAN_BBOX);
       setBitmapLayer(getBitmapLayer(imageUrl));
       setSliderRangeLimit(urls.length - 1);
     }
@@ -136,7 +136,7 @@ const DataLayerDashboard = () => {
       if (sliderChangeComplete) {
         const urls = getUrls();
         if (urls[sliderValue]) {
-          const imageUrl = urls[sliderValue].replace('{bbox}', boundingBox);
+          const imageUrl = urls[sliderValue].replace('{bbox}', EUROPEAN_BBOX);
           setBitmapLayer(getBitmapLayer(imageUrl));
         }
       }
@@ -179,8 +179,9 @@ const DataLayerDashboard = () => {
   const getBitmapLayer = (url) => {
     return {
       id: 'bitmap-layer',
-      bounds: boundingBox,
-      image: url
+      bounds: EUROPEAN_BBOX,
+      image: url,
+      _imageCoordinateSystem: COORDINATE_SYSTEM.LNGLAT,
     }
   }
 


### PR DESCRIPTION
I've added code to request the WMS image as the right size, namely setting the bbox to cover Europe, not just the AOI the user has set. This still isn't great, as we only have the Europe bbox, the raster image should be in EPSG:3587 (WGS84 Web Mercator), rather than EPSG:4326 (WGS84), these are subtly different SRS's, we are fixing in code, but should probably be a fix in GeoServer. Another part of this fix is to set the layer to use LNG/LAT, not LAT/LNG, which is the default for mapbox maps, that would also be fixed if the data were in EPSG:3587.