### PR TITLE
Hide Slider if less than 2 images

### DIFF
--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -204,7 +204,7 @@ const DataLayerDashboard = () => {
   const formatTooltip = value => moment(Object.assign({}, Object.keys(currentLayer?.urls))[value]).format('LLL');
 
   const getSlider = (index) => {
-    if (currentLayer?.urls) {
+    if (currentLayer?.urls && Object.keys(currentLayer?.urls).length > 1) {
       return (
         <div style={{
           position: 'absolute',
@@ -247,6 +247,8 @@ const DataLayerDashboard = () => {
         </div>
       );
     }
+
+    return null
   }
 
   const getLegend = () => {


### PR DESCRIPTION
When showing data layers, there is no point showing the slider when there is zero or one data layers, only where there are 2 or more. I have added a little check to not display the slider in this case.

## Testing

Load the `Environment -> Forecast`, this will have no slider.
Load the `Weather Forecast -> Short term -> Wind`, this will have a slider.