### PR TITLE
SAFB-299: Prevent In-Situ Popup Crashing

### DIFF
--- a/src/pages/In-situ/Components/Tooltip.js
+++ b/src/pages/In-situ/Components/Tooltip.js
@@ -8,7 +8,7 @@ import { Popup } from 'react-map-gl';
 import { formatDate } from '../../../store/utility';
 
 const Tooltip = ({ object = {}, coordinate }) => {
-  const { id, description, location, direction, last_update } = object.properties;
+  const { id, description, location, direction, last_update } = object.properties.properties;
   return (
     <Popup
       longitude={coordinate[0]}
@@ -26,8 +26,10 @@ const Tooltip = ({ object = {}, coordinate }) => {
           <Col md={10} className='text-white ms-auto'>
             <p className='mb-1'>Camera Number: {id}</p>
             <p className='mb-1'>
-              Camera Location: Lon. {location.longitude}, 
-              Lat. {location.latitude}
+              Camera Location:
+              <br />
+              Lon. {location?.longitude}, 
+              Lat. {location?.latitude}
             </p>
             <p className='mb-1'>Camera Direction: {direction}&#176;</p>
             <p className='mb-1'>

--- a/src/pages/In-situ/index.js
+++ b/src/pages/In-situ/index.js
@@ -73,9 +73,7 @@ const InSituAlerts = () => {
       clusterIconSize: 35,
       getPinSize: () => 35,
       pixelOffset: [-18,-18],
-      pinSize: 25,
-      onGroupClick: true,
-      onPointClick: true,
+      pinSize: 25
     });
   };
 


### PR DESCRIPTION
Closes #SAFB-299

For some reason, `object.properties` passed to the popup is now `object.properties.properties`,
no idea why. This fixes (and added some optional chaining to prevent crashing in future), but is
likely indicative of a larger issue (how did the extra `properties` get there)?

Also added in a break tag to format the lat/lon values more nicely, and removed some properties from the GeojsonLayer that were not required.