### PR TITLE
SAFB-247: Default Frequency and Resolution to Null

### DIFF
--- a/src/pages/DataLayer/FireAndBurnedArea.js
+++ b/src/pages/DataLayer/FireAndBurnedArea.js
@@ -51,8 +51,8 @@ const FireAndBurnedArea = ({
       parameters: {
         start: `${formData.startDate}T00:00:00.000`,
         end: `${formData.endDate}T00:00:00.000`,
-        frequency: formData.frequency,
-        resolution: formData.resolution,
+        frequency: formData.frequency || null,
+        resolution: formData.resolution || null,
       },
     }
 


### PR DESCRIPTION
Closes #SAFB-247

Changed the payload being dispatched from `FireAndBurnedArea` to default both `frequency` and `resolution` fields to null instead of empty strings.
    
The reason for not defaulting inside the form itself is because even if they are initialised to null at first, typing then deleting will turn the value into an empty string anyway, so catching it in the final payload is a way to force a null value every time. 

Validation prevents zero or negative numbers, so the only falsy value possible is an empty string. 