### PR TITLE
Fix display of event in popup and saving of changes

### DIFF
--- a/src/pages/Events/Components/Tooltip.js
+++ b/src/pages/Events/Components/Tooltip.js
@@ -176,7 +176,7 @@ const Tooltip = ({ object, coordinate, isEdit = false, setIsEdit, setFavorite, t
                 {
                   editToggle ?
                     <Input type='text' className='tootip-input ms-2' value={damage ? damage : ''} onChange={(e) => { setDamage(e.target.value) }} />
-                    : event ? event.damage : 'not recorded'
+                    : event ? event.estimated_damage : 'not recorded'
                 }
               </CardSubtitle>
             </Col>

--- a/src/pages/Events/index.js
+++ b/src/pages/Events/index.js
@@ -163,7 +163,7 @@ const EventAlerts = ({ t }) => {
 
   const showTooltip = info => {
     if (info.picked && info.object) {
-      setSelectedAlert(info.object.id);
+      setSelectedAlert(info.object.properties.id);
       setHoverInfo(info);
     } else {
       setHoverInfo({});


### PR DESCRIPTION
The name of the field in the event had changed from `damage`, to `estimated_damage`, so changed that to display the value in the tooltip popup.

The tooltip was never displaying the event data due to the shape of the data having changed, to use GeoJSON. This was a good thing, but had unintended consequences. Simply getting the ID from the properties object instead of directly from the picked info.object fixed this problem.

IssueID SAFB-220