### PR TITLE
feat(frontend): Event tooltip end date removed time

### DIFF
--- a/src/pages/Events/Components/Tooltip.js
+++ b/src/pages/Events/Components/Tooltip.js
@@ -11,7 +11,7 @@ import {
 } from 'reactstrap';
 import { Popup } from 'react-map-gl';
 import { useNavigate } from 'react-router-dom';
-import { formatDate, formatDateOnly } from '../../../store/utility';
+import { formatDate } from '../../../store/utility';
 import classnames from 'classnames';
 import DatePicker from '../../../components/DateRangePicker/DatePicker';
 
@@ -124,7 +124,7 @@ const Tooltip = ({ object, coordinate, isEdit = false, setIsEdit, setFavorite, t
                         isTooltipInput={true}
                         date={endDate}
                       />
-                      : event && event.end_date ? formatDateOnly(event.end_date) : 'not set'
+                      : event && event.end_date ? formatDate(event.end_date, 'YYYY-MM-DD') : 'not set'
                   }
                 </div>
               </CardSubtitle>

--- a/src/store/utility.js
+++ b/src/store/utility.js
@@ -27,11 +27,6 @@ export const formatDate = (date, format = 'YYYY-MM-DD HH:mm:ss') => {
   return moment(date).format(format)
 }
 
-export const formatDateOnly = (date, format = 'YYYY-MM-DD') => {
-  return moment(date).format(format)
-}
-
-
 export const getPropertyValue = (searchObject = {}, targetProperty) => {
   const match = searchObject[targetProperty];
   const children = searchObject?.children;


### PR DESCRIPTION
now the event popup removes the time portion of the end date as we don't allow that to be set