### PR TITLE
SAFB-246: Split Data Source Options

### DIFF
--- a/src/pages/DataLayer/DataLayer.js
+++ b/src/pages/DataLayer/DataLayer.js
@@ -21,7 +21,7 @@ const DataLayer = ({
   metaData,
   isMetaDataLoading,
   operationalSourceOptions,
-  domainOptions,
+  operationalDomainOptions,
   layerSource,
   operationalMapLayers,
   dataDomain,
@@ -150,7 +150,7 @@ const DataLayer = ({
                   value={dataDomain}
                 >
                   <option value={''} >Domain: All</option>
-                  {domainOptions?.map((option) => (
+                  {operationalDomainOptions?.map((option) => (
                     <option key={option} value={option}>
                       Domain: {option}
                     </option>
@@ -212,7 +212,7 @@ DataLayer.propTypes = {
   metaData: PropTypes.object,
   isMetaDataLoading: PropTypes.bool,
   operationalSourceOptions: PropTypes.array,
-  domainOptions: PropTypes.array,
+  operationalDomainOptions: PropTypes.array,
   layerSource: PropTypes.any,
   operationalMapLayers: PropTypes.any,
   dataDomain: PropTypes.any,

--- a/src/pages/DataLayer/OnDemandDataLayer.js
+++ b/src/pages/DataLayer/OnDemandDataLayer.js
@@ -14,7 +14,7 @@ const OnDemandDataLayer = ({
   t,
   mapRequests,
   onDemandSourceOptions,
-  domainOptions,
+  onDemandDomainOptions,
   setActiveTab,
   setCurrentLayer,
   layerSource,
@@ -159,7 +159,7 @@ const OnDemandDataLayer = ({
                     value={dataDomain}
                   >
                     <option value={''} >Domain : All</option>
-                    {domainOptions?.map((option) => (
+                    {onDemandDomainOptions?.map((option) => (
                       <option key={option} value={option}>
                           Domain: {option}
                       </option>
@@ -240,7 +240,7 @@ OnDemandDataLayer.propTypes = {
   t: PropTypes.any,
   mapRequests: PropTypes.any,
   onDemandSourceOptions: PropTypes.array,
-  domainOptions: PropTypes.array,
+  onDemandDomainOptions: PropTypes.array,
   setActiveTab: PropTypes.func,
   setCurrentLayer: PropTypes.any,
   layerSource: PropTypes.any,

--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -310,7 +310,6 @@ const DataLayerDashboard = () => {
     t,
     layerSource,
     setLayerSource,
-    operationalDomainOptions,
     currentLayer,
     setCurrentLayer,
     dataDomain,
@@ -392,6 +391,7 @@ const DataLayerDashboard = () => {
                 domain: dataDomain
               })}
               operationalSourceOptions={operationalSourceOptions}
+              operationalDomainOptions={operationalDomainOptions}
               dispatch={dispatch}
               metaData={metaData}
               isMetaDataLoading={isMetaDataLoading}
@@ -405,6 +405,7 @@ const DataLayerDashboard = () => {
                 domain: dataDomain
               })}
               onDemandSourceOptions={onDemandSourceOptions}
+              onDemandDomainOptions={onDemandDomainOptions}
               dispatch={dispatch}
               setActiveTab={setActiveTab}
               {...sharedMapLayersProps}


### PR DESCRIPTION
Began splitting the source select options between operational and on-demand, to allow both panels to display different options.