### PR TITLE
SAFB-239: Fetch Activity Select Options

### DIFF
--- a/src/pages/Chatbot/People/Components/SortSection.js
+++ b/src/pages/Chatbot/People/Components/SortSection.js
@@ -9,7 +9,16 @@ import { setFilters } from '../../../../store/people/action';
 import { getFilteredRec } from '../../filter';
 
 
-const SortSection = ({ t, status, activity, sortOrder, setStatus, setActivity, setSortOrder }) => {
+const SortSection = ({ 
+  t, 
+  status, 
+  activity, 
+  sortOrder, 
+  setStatus, 
+  setActivity, 
+  setSortOrder,
+  activitiesOptions
+}) => {
   const { allPeople } = useSelector(state => state.people);
   const dispatch = useDispatch();
 
@@ -77,9 +86,9 @@ const SortSection = ({ t, status, activity, sortOrder, setStatus, setActivity, s
             data-testid='activity'
           >
             <option value={''} >--Activity--</option>
-            {'<!-- To be decided when Activity API has a data structure -->'}
-            <option value="Surveillance" >{t('Surveillance').toUpperCase()}</option>
-            <option value="Search and rescue" >{t('Search and rescue').toUpperCase()}</option>
+            {activitiesOptions.map(option => (
+              <option key={option} value={t(`${option}`)}>{option}</option>
+            ))}
           </Input>
         </Col>
       </Row>
@@ -94,6 +103,7 @@ SortSection.propTypes = {
   setStatus: PropTypes.func,
   setActivity: PropTypes.func,
   setSortOrder: PropTypes.func,
+  activitiesOptions: PropTypes.array,
   t: PropTypes.func
 }
 

--- a/src/pages/Chatbot/People/index.js
+++ b/src/pages/Chatbot/People/index.js
@@ -13,6 +13,7 @@ import { getBoundingBox, getViewState, getIconLayer } from '../../../helpers/map
 
 import { useTranslation } from 'react-i18next';
 import { MAP_TYPES } from '../../../constants/common';
+import { fetchEndpoint } from '../../../helpers/apiHelper';
 
 const People = () => {
   const defaultAoi = useSelector(state => state.user.defaultAoi);
@@ -34,8 +35,18 @@ const People = () => {
   const [currentZoomLevel, setCurrentZoomLevel] = useState(undefined);
   const [newWidth, setNewWidth] = useState(600);
   const [newHeight, setNewHeight] = useState(600);
+  const [activitiesOptions, setActivitiesOptions] = useState([]);
 
   const dispatch = useDispatch();
+
+  useEffect(() => {
+    (async () => {
+      const activitiesOptions = await fetchEndpoint(
+        '/chatbot/people/activities'
+      );
+      setActivitiesOptions(activitiesOptions);
+    })();
+  }, [])
 
   useEffect(() => {
     const dateRangeParams = dateRange
@@ -108,6 +119,7 @@ const People = () => {
             setStatus={setStatus}
             setActivity={setActivity}
             setSortOrder={setSortOrder}
+            activitiesOptions={activitiesOptions}
           />
           <Row>
             <Col xl={12} className='px-3'>


### PR DESCRIPTION
Closes #SAFB-239

This adds a fetch request to get the activity select options for Chatbot/People,and replaces the hardcoded options currently in the component.