### PR TITLE
Fix missing data in popup and scrolling within popup

### DIFF
--- a/src/pages/In-situ/Components/AlertList.js
+++ b/src/pages/In-situ/Components/AlertList.js
@@ -30,20 +30,8 @@ const AlertList = ({
   const dispatch = useDispatch();
 
   const getIconLayer = (alerts) => {
-    const data = alerts?.map((alert) => {
-      const {
-        geometry,
-        ...properties
-      } = alert;
-      return {
-        type: 'Feature',
-        properties: properties,
-        geometry: geometry,
-      };
-    });
-
     return new GeoJsonPinLayer({
-      data,
+      data: alerts,
       dispatch,
       setViewState,
       getPosition: (feature) => feature.geometry.coordinates,

--- a/src/pages/In-situ/Components/Tooltip.js
+++ b/src/pages/In-situ/Components/Tooltip.js
@@ -9,12 +9,14 @@ import { formatDate } from '../../../store/utility';
 
 const Tooltip = ({ object }) => {
   const obj = (object?.objects) ? object.objects : [object.object];
+
   return (
     <Popup
       longitude={obj[0].geometry.coordinates[0]}
       latitude={obj[0].geometry.coordinates[1]}
       offsetLeft={15}
       dynamicPosition={true}
+      captureScroll={true}
       anchor='left'
       className="cameras-tooltip"
       style={{ borderRadius: '10px' }}>


### PR DESCRIPTION
I've fixed the missing data in the popup, for when the user clicks the list item. I don't like the code in this area, but the alerts list and the index file both create layers and I they overwrite each other. I suspect it works, but not well. The problem was that the data is already a GeoJSON feature, but in the AlertsList, we are re-shaping it to a Feature, incorrectly, removing that, fixed the problem.

I also found a quick fix for using the scroll wheel, in popus, so fixed that at the same time.

IssueID SAFB-259