### PR TITLE
feat(frontend): correctly set bbox for BitmapLayer

### DIFF
--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -101,8 +101,8 @@ const DataLayerDashboard = () => {
 
   useEffect(() => {
     // Remove comments if it's required to send date-time range and bbox value for filter
-    // const dateRangeParams = dateRange 
-    //   ? { start: dateRange[0], end: dateRange[1] } 
+    // const dateRangeParams = dateRange
+    //   ? { start: dateRange[0], end: dateRange[1] }
     //   : {};
 
     const options = {
@@ -177,8 +177,8 @@ const DataLayerDashboard = () => {
     }
   }, [activeTab, currentLayer, metaData]);
 
-  // This takes an array of objects and recursively filters out sibling 
-  // objects that do not match the search term. It retains the original data 
+  // This takes an array of objects and recursively filters out sibling
+  // objects that do not match the search term. It retains the original data
   // shape and all children of matching objects.
   const searchDataTree = (data, str) => {
     const searchTerm = str.toLowerCase();
@@ -212,9 +212,17 @@ const DataLayerDashboard = () => {
   }
 
   const getBitmapLayer = (url) => {
+    /*
+     extract bounds from url; if this is an operational layer, it will have been replaced by dataLayerBoundingBox
+     if this is an on-demand layer, it will have been hard-coded by the backend
+    */
+    const urlSearchParams = new URLSearchParams(url);
+    const urlParams = Object.fromEntries(urlSearchParams.entries());
+    const bounds = urlParams?.bbox ? urlParams.bbox.split(',').map(Number) : dataLayerBoundingBox
+
     return {
       id: 'bitmap-layer',
-      bounds: dataLayerBoundingBox,
+      bounds: bounds,
       image: url,
       _imageCoordinateSystem: COORDINATE_SYSTEM.LNGLAT,
       opacity: 0.5


### PR DESCRIPTION
Dynamically extract bbox from URL of bitmap for BitmapLayer.

If this is an operational layer, then the bbox in the URL will have been replaced in the frontend either by the hard-coded `EUROPEAN_BBOX` or the bbox of the user's AOI (depending on some config settings).  If this is an on-demand layer, then the bbox in the URL will have been pre-computed by the backend.