### PR TITLE
feat(frontend): Only show errors on Blur

### DIFF
--- a/src/pages/DataLayer/WildfireSimulation.js
+++ b/src/pages/DataLayer/WildfireSimulation.js
@@ -206,6 +206,8 @@ const WildfireSimulation = ({
             validationSchema={WildfireSimulationSchema}
             onSubmit={onSubmit}
             id="wildfireSimulationForm"
+            validateOnChange={false}
+            validateOnBlur={true}
           >
             {({
               values,
@@ -258,7 +260,7 @@ const WildfireSimulation = ({
                             value={values.simulationTitle}
                             placeholder="[Type Simulation Title]"
                           />
-                          {getError('simulationTitle', errors, touched, false)}
+                          {touched.simulationTitle && getError('simulationTitle', errors, touched, false)}
                         </FormGroup>
                       </Row>
 
@@ -280,7 +282,7 @@ const WildfireSimulation = ({
                             value={values.simulationDescription}
                             placeholder="Simulation description"
                           />
-                          {getError('simulationDescription', errors, touched, false)}
+                          {touched.simulationDescription && getError('simulationDescription', errors, touched, false)}
                         </FormGroup>
                       </Row>
                     </div>
@@ -345,7 +347,7 @@ const WildfireSimulation = ({
                           value={values.simulationTimeLimit}
                           placeholder="Type Limit [hours]"
                         />
-                        {getError('simulationTimeLimit', errors, touched, false)}
+                        {touched.simulationTimeLimit && getError('simulationTimeLimit', errors, touched, false)}
                       </FormGroup>
                     </Row>
 
@@ -379,8 +381,8 @@ const WildfireSimulation = ({
                           value={values.mapSelection}
                           placeholder='Enter Well Known Text or draw a polygon on the map'
                         />
-                        {getError('mapSelection', errors, touched, false)}
-                        {getError('mapSelectionArea', errors, touched, false, true)}
+                        {touched.mapSelection && getError('mapSelection', errors, touched, false)}
+                        {touched.mapSelection && getError('mapSelectionArea', errors, touched, false, true)}
                       </FormGroup>
                     </Row>
 
@@ -418,7 +420,7 @@ const WildfireSimulation = ({
                               }
                             />
                           </Col>
-                          {getError('ignitionDateTime', errors, touched, false)}
+                          {touched.ignitionDateTime && getError('ignitionDateTime', errors, touched, false)}
                         </Row>
                       </FormGroup>
                     </Row>
@@ -440,7 +442,7 @@ const WildfireSimulation = ({
                           className='m-0'
                           style={{ cursor: 'pointer' }}
                         />
-                        {getError('simulationFireSpotting', errors, touched, false)}
+                        {touched.simulationFireSpotting && getError('simulationFireSpotting', errors, touched, false)}
                       </FormGroup>
                     </Row>
                   </Col>
@@ -513,7 +515,7 @@ const WildfireSimulation = ({
                                       onChange={handleChange}
                                       onBlur={handleBlur}
                                     />
-                                    {renderDynamicError(errors.boundaryConditions?.[position]?.timeOffset)}
+                                    {touched.boundaryConditions && renderDynamicError(errors.boundaryConditions?.[position]?.timeOffset)}
                                   </td>
                                   <td>
                                     <Input
@@ -523,7 +525,7 @@ const WildfireSimulation = ({
                                       onChange={handleChange}
                                       onBlur={handleBlur}
                                     />
-                                    {renderDynamicError(errors.boundaryConditions?.[position]?.windDirection)}
+                                    {touched.boundaryConditions && renderDynamicError(errors.boundaryConditions?.[position]?.windDirection)}
                                   </td>
                                   <td>
                                     <Input
@@ -533,7 +535,7 @@ const WildfireSimulation = ({
                                       onChange={handleChange}
                                       onBlur={handleBlur}
                                     />
-                                    {renderDynamicError(errors.boundaryConditions?.[position]?.windSpeed)}
+                                    {touched.boundaryConditions && renderDynamicError(errors.boundaryConditions?.[position]?.windSpeed)}
                                   </td>
                                   <td>
                                     <Input
@@ -543,7 +545,7 @@ const WildfireSimulation = ({
                                       onChange={handleChange}
                                       onBlur={handleBlur}
                                     />
-                                    {renderDynamicError(errors.boundaryConditions?.[position]?.fuelMoistureContent)}
+                                    {touched.boundaryConditions && renderDynamicError(errors.boundaryConditions?.[position]?.fuelMoistureContent)}
                                   </td>
                                 </tr>
                               ))}


### PR DESCRIPTION
Wilfire Simulation Form only shows errors when field has been touched This removes the wall of error messages for fields that have yet to be filled in.

Fix is to only display the error message once a field has been touched
This happens whenever a user tabs into or out of a field.

In the case of boundary conditions, touching any of the boundary condition fields enables the errors for the rest of the boundary condition fields.

Selecting a too-large polygon will not show an error straight away, as this bypasses the ‘touching’ of the field. However, it will appear if the user tabs into/off the field, or when submitting the form.

Fields will still receive an error border, but this is not highly visible because the error is not shown until the user tabs on to/off the field. (And it’s probably best to keep this, as it subtly alerts the user to which fields are required)

IssueID SAFB-299