### PR TITLE
feat(frontend): added a constant buffer to the Wildfire Simulation geometry

### DIFF
--- a/src/pages/DataLayer/WildfireSimulation.js
+++ b/src/pages/DataLayer/WildfireSimulation.js
@@ -27,6 +27,9 @@ const MAX_GEOMETRY_AREA = {
   value: 40000000000
 };
 
+// increase the bbox used to view Wildfire layers by 20 kms
+const DEFAULT_WILDFIRE_GEOMETRY_BUFFER = 20
+
 const TIME_LIMIT = 72;
 
 const TABLE_HEADERS = [
@@ -157,6 +160,7 @@ const WildfireSimulation = ({
     const payload = {
       data_types: layerTypes.map(item => item.id),
       geometry: transformedGeometry,
+      geometry_buffer_size: DEFAULT_WILDFIRE_GEOMETRY_BUFFER,
       title: formData.simulationTitle,
       parameters: {
         description: formData.simulationDescription,


### PR DESCRIPTION
This ensures that the bbox requested from the geoserver will extend beyond the original geometry (which is treated as the ignition point by the Wildfire Simulation service).

The backend API has already been updated to accept a buffer.