### PR TITLE
feat(frontend): use array of timeseries_urls

### DIFF
--- a/src/pages/DataLayer/DataLayerInformation.js
+++ b/src/pages/DataLayer/DataLayerInformation.js
@@ -39,7 +39,7 @@ const DataLayerInformationComponent = ({
   const [selectedDomain, setSelectedDomain] = useState(null);
   const [contextMenuKey, setContextMenuKey] = useState(0);
   const chartContainerRef = useRef(null);
-  const timeseriesExists = !!currentLayer?.timeseries_url;
+  const timeseriesExists = !!currentLayer?.timeseries_urls;
 
   let title = currentLayer?.title
   if (currentLayer?.units) {


### PR DESCRIPTION
The backend now sends the URLs to use for getting timeseries info as an array (w/ each entry having a maximum of 100 timestamps) of URLs rather than one single URL.  The frontend then stitches together those responses.

This PR makes the flag that tells the frontend whether or not to display the GetTimeseries context menu based on the presence of this new variable `timeries_urls` rather than the deprecated one `timeseries_url`.