### PR TITLE
feat(frontend): added time selection to mission creation form

### DIFF
--- a/src/components/DateRangePicker/DateRange.js
+++ b/src/components/DateRangePicker/DateRange.js
@@ -23,6 +23,7 @@ const DateComponent = ({
   defaultDateRange,
   placeholder=null,
   isDateRangeDisabled=false,
+  isTimeEnabled=false,
   onChange= () => {},
   i18n
 }) => {
@@ -69,6 +70,7 @@ const DateComponent = ({
         </div>
 
         <Flatpickr
+          data-enable-time={isTimeEnabled}
           className="form-control d-block"
           placeholder={placeholder ? placeholder : 'dd/mm/yy'}
           ref={fp}
@@ -80,7 +82,7 @@ const DateComponent = ({
           disabled={isDateRangeDisabled}
           options={{
             mode: 'range',
-            dateFormat: 'd/m/y',
+            dateFormat: isTimeEnabled ? 'd/m/y h:i K': 'd/m/y',
             defaultDate,
             locale: trsnalation
           }}
@@ -105,6 +107,7 @@ DateComponent.propTypes = {
   defaultDateRange: PropTypes.array,
   placeholder: PropTypes.string,
   isDateRangeDisabled: PropTypes.bool,
+  isTimeEnabled: PropTypes.bool,
   i18n: PropTypes.object
 }
 

--- a/src/pages/Chatbot/Missions/Components/CreateMission.js
+++ b/src/pages/Chatbot/Missions/Components/CreateMission.js
@@ -68,7 +68,7 @@ const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
 
   const handleDateRangePicker = (dates) => {
     setDateRange(dates.map(date => 
-      moment(date).format('YYYY-MM-DD'))
+      moment(date).toISOString())
     );
   }
 
@@ -154,6 +154,7 @@ const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
         defaultDateRange={dateRange}
         isTooltipInput={true}
         showIcons={true}
+        isTimeEnabled={true}
         onChange={(dates) => {validateField('dateRange', dates)}}
       />
       {getError('dateRange', errors, errors, false)}


### PR DESCRIPTION
Used the built-in properties of `react-flatpickr` to add a time selection section to the date selection component in the "Create Mission" form.  Then made sure that the full datetime is passed to the backend.

This will require a PR for the backend as well - to no longer replace the time elements w/ default values.