### PR TITLE
Prevent legend being cut-off

### DIFF
--- a/src/assets/scss/custom/pages/_data-layer.scss
+++ b/src/assets/scss/custom/pages/_data-layer.scss
@@ -35,8 +35,6 @@
 }
 
 .legend {
-    display: flex;
-    align-items: center;
     overflow-y: auto;
     overflow-x: hidden;
     height: 80%;


### PR DESCRIPTION
For some reason, the top of the legend was being cut-off, removing the flex styling seems to have fixed it, but I don't honestly know why, I've never seen this before.

IssueID [SAFB-335](https://astrosat.atlassian.net/browse/SAFB-335)

[SAFB-335]: https://astrosat.atlassian.net/browse/SAFB-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ