### PR TITLE
Introduce interpolated strings for feature info text

### DIFF
--- a/src/pages/DataLayer/DataLayerInformation.js
+++ b/src/pages/DataLayer/DataLayerInformation.js
@@ -82,7 +82,7 @@ const DataLayerInformationComponent = ({
   }, [currentViewState])
 
   useEffect(()=> {
-    getPixelValue();
+    getFeatureInfo();
   }, [featureInfoData])
 
   useEffect(() => {
@@ -106,7 +106,7 @@ const DataLayerInformationComponent = ({
       <>{selectedPixel?.length > 0 && featureInfoData?.features?.length > 0 && <Card color="dark default-panel mt-3">
         <div className='d-flex justify-content-between align-items-center'>
           <div className='p-3 empty-loading'>
-            {getPixelValue()}
+            {getFeatureInfo()}
           </div>
           <h4 className='ps-3 mb-0'><i className='meta-close' onClick={clearInfo}>x</i></h4>
         </div>
@@ -274,7 +274,7 @@ const DataLayerInformationComponent = ({
     setSelectedDomain(null);
   }
 
-  const getPixelValue = () => {
+  const getFeatureInfo = () => {
     let valueString = '';
 
     if (featureInfoData?.features && featureInfoData.features[0].properties) {
@@ -284,14 +284,18 @@ const DataLayerInformationComponent = ({
 
         // Extract placeholder keys to be replaced.
         const keys = featureString.match(/[^{}]+(?=})/g);
-
-        const properties = featureInfoData.features[0].properties;
-
         valueString = featureString;
-        // Replace placeholders in string with values from properties object.
-        keys.forEach(key => {
-          valueString = valueString.replace(`{{${key}}}`, get(properties, key));
-        });
+
+        // If there are keys to inject into the string, then iterate
+        // around them and do so.
+        if (keys) {
+          const properties = featureInfoData.features[0].properties;
+
+          // Replace placeholders in string with values from properties object.
+          keys.forEach(key => {
+            valueString = valueString.replace(`{{${key}}}`, get(properties, key));
+          });
+        }
       } else {
         Object.keys(featureInfoData?.features[0]?.properties).forEach(key => {
           valueString = `${valueString} Value of pixel: ${featureInfoData.features[0].properties[key]}\n`;


### PR DESCRIPTION
Added the ability to inject data into the interpolated `feature_string` defined in the backend against each data layer. They now all come with an optional `feature_string`, if it exists, we extract data from the feature info data response into a known string, with parameter substitution, otherwise we do as it currently does an use the hard-coded string and inject a value and unit, if one exists.

**NOTE:** This should only be merged after branch `move-feature-string-up-for-operational-layers` of the gateway repo, has been merged. We still need a way to collect and add all the possible custom interpolated strings and the properties they use. I know there is an import CSV, but the spreadsheet used will need to be updated first.

IssueID SAFB-318