### PR TITLE
389, 390: Global date filtering and icon click map navigation.

### DIFF
--- a/src/pages/Chatbot/Comms/index.js
+++ b/src/pages/Chatbot/Comms/index.js
@@ -152,10 +152,6 @@ const Comms = ({ pollingFrequency }) => {
 
   const onClick = info => {
     const { id } = info?.object?.properties ?? {};
-    // only move map if icon is clicked
-    if (info.object) {
-      setViewState(getViewState(info.coordinate, currentZoomLevel));
-    }
     setCommID(commID === id ? undefined : id);
   };
 

--- a/src/pages/Chatbot/Missions/index.js
+++ b/src/pages/Chatbot/Missions/index.js
@@ -162,10 +162,6 @@ const Missions = ({ pollingFrequency }) => {
 
   const onClick = info => {
     const { id } = info?.object?.properties ?? {};
-    // only move map if icon is clicked
-    if (info.object) {
-      setViewState(getViewState(info.coordinate, currentZoomLevel));
-    }
     setMissionId(missionId === id ? undefined : id);
   };
 

--- a/src/pages/Chatbot/People/index.js
+++ b/src/pages/Chatbot/People/index.js
@@ -161,10 +161,6 @@ const People = ({ pollingFrequency }) => {
 
   const onClick = info => {
     const { id } = info?.object?.properties ?? {};
-    // only move map if icon is clicked
-    if (info.object) {
-      setViewState(getViewState(info.coordinate, currentZoomLevel));
-    }
     setPeopleId(peopleId === id ? undefined : id);
   };
 

--- a/src/pages/Chatbot/Reports/index.js
+++ b/src/pages/Chatbot/Reports/index.js
@@ -138,10 +138,6 @@ const Reports = ({ pollingFrequency }) => {
 
   const handleClick = info => {
     const { id } = info?.object?.properties ?? {};
-    // only move map if icon is clicked
-    if (info.object) {
-      setViewState(getViewState(info.coordinate, currentZoomLevel));
-    }
     setReportId(reportId === id ? undefined : id);
   };
 


### PR DESCRIPTION
Two bugs:

1. The global date range is to make sure that the selected dates are sent along with the requests, so that the correctly filtered data is returned.

2. The viewstate change is so that the map will re-center itself when an icon is clicked, not just when the card in the sidebar is clicked.

Closes  #SAFB-389 and #SAFB-394