### PR TITLE
Fix drawing mission polygon breaking app

### DIFF
--- a/src/pages/Chatbot/Missions/index.js
+++ b/src/pages/Chatbot/Missions/index.js
@@ -23,7 +23,6 @@ import {
   getAllMissions,
   resetMissionResponseState,
 } from '../../../store/missions/action';
-import { getWKTfromFeature } from '../../../store/utility';
 
 const Missions = ({ pollingFrequency }) => {
   const defaultAoi = useSelector(state => state.user.defaultAoi);
@@ -217,7 +216,7 @@ const Missions = ({ pollingFrequency }) => {
             setNewHeight={setNewHeight}
             setCoordinates={setCoordinates}
             togglePolygonMap={togglePolygonMap}
-            coordinates={getWKTfromFeature(coordinates)}
+            coordinates={coordinates}
             onClick={onClick}
           />
         </Col>


### PR DESCRIPTION
Previously we switched from using WKT as the internal map feature format to GeoJSON, but this was was missed. Simple fix was to not try to convert the value to GeoJSON as it already was in GeoJSON.

This was impossible to test and fix until after Allyn had fixed the backend macking a `GetTeams` API request on the backend. Now he prevents this if the user only has the `citizen` role.

I will be adding to this PR the ability to disable this tab, when the user only has the `citizen` role, as those users should not be able to interact with `Missions`.

IssueID SAFB-395