### PR TITLE
feat(frontend): Get polling working for people

### DIFF
--- a/src/helpers/pollingHelper.js
+++ b/src/helpers/pollingHelper.js
@@ -12,6 +12,7 @@ import {
   setNewNotificationState,
   getAllMapRequests,
   setNewMapRequestState,
+  getAllPeople,
 } from '../store/appAction';
 
 const MILLISECONDS = 1000;
@@ -75,6 +76,7 @@ const PollingHelper = props => {
       getAllNotifications({ ...notificationParams, ...dateRangeParams }),
     );
     dispatch(getAllMapRequests({ ...mapRequestParams, ...dateRangeParams }));
+    dispatch(getAllPeople({ ...dateRangeParams }, {}));
   };
 
   useEffect(() => {

--- a/src/pages/Dashboard/Components/Notifications.js
+++ b/src/pages/Dashboard/Components/Notifications.js
@@ -76,7 +76,7 @@ const NotificationsBar = ({ t }) => {
     const params = {
       bbox: undefined,
       default_date: false,
-      default_bbox: false,
+      default_bbox: true,
     };
     const feFilters = {};
     dispatch(getAllPeople(params, feFilters));


### PR DESCRIPTION
Done as draft for now in case I've missed something, this was suspiciously straightforward...

- added dispatch to polling helper, confirmed it is happening
- no need for notification counts being maintained in state, as people isn't in sidebar menu so doesn't have a notification widget
- fixed dashboard so it uses user AOI. This means we now see people...

IssueID SAFB-397