### PR TITLE
Rename Comms to Communications

### DIFF
--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -54,5 +54,6 @@
   "Outdoors": "Outdoors",
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
-  "Terrain": "Terrain"
+  "Terrain": "Terrain",
+  "Communications": "Kommunikationen"
 }

--- a/src/locales/el/common.json
+++ b/src/locales/el/common.json
@@ -115,5 +115,6 @@
   "Outdoors": "Outdoors",
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
-  "Terrain": "Terrain"
+  "Terrain": "Terrain",
+  "Communications": "Επικοινωνίες"
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -109,5 +109,6 @@
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
   "Terrain": "Terrain",
-  "no-available-data": "No available data"
+  "no-available-data": "No available data",
+  "Communications": "Communications"
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -115,5 +115,6 @@
   "Outdoors": "Outdoors",
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
-  "Terrain": "Terrain"
+  "Terrain": "Terrain",
+  "Communications": "Comunicacións"
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -108,5 +108,6 @@
   "Outdoors": "Outdoors",
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
-  "Terrain": "Terrain"
+  "Terrain": "Terrain",
+  "Communications": "Communications"
 }

--- a/src/locales/it/common.json
+++ b/src/locales/it/common.json
@@ -115,5 +115,6 @@
   "Outdoors": "Outdoors",
   "Satellite Streets": "Satellite Streets",
   "Navigation": "Navigation",
-  "Terrain": "Terrain"
+  "Terrain": "Terrain",
+  "Communications": "Comunicazione"
 }

--- a/src/pages/Chatbot/index.js
+++ b/src/pages/Chatbot/index.js
@@ -98,7 +98,7 @@ const Chatbot = () => {
                 <span className="d-none d-sm-block me-2">
                   <i className="fas fa-envelope"></i>
                 </span>
-                <span className="d-block">{t('Comms')}</span>
+                <span className="d-block">{t('Communications')}</span>
               </NavLink>
             </NavItem>
             <NavItem className={!isProfessionalUser ? 'disabled' : ''}>

--- a/src/pages/Dashboard/Components/Notifications.js
+++ b/src/pages/Dashboard/Components/Notifications.js
@@ -164,12 +164,12 @@ const NotificationsBar = ({ t }) => {
             linkURL="/chatbot?tab=3"
           />
           <NotificationCard
-            cardName={t('Comms')}
+            cardName={t('Communications')}
             iconClass="fas fa-envelope"
             contentRenderer={() =>
               renderer(
                 t('No new communications', { ns: 'dashboard' }),
-                'Comms',
+                'Communications',
                 communicationStatusCounts,
               )
             }


### PR DESCRIPTION
The short-form Comms could be misleading to some, so renamed it to be explicit. There is no translations for this, I don't see anything in the spreadsheet of the language files, so that will probably have to be done at some point too.