### PR TITLE
Prevent GetFeatureInfo crashing app

### DIFF
--- a/src/pages/DataLayer/DataLayerInformation.js
+++ b/src/pages/DataLayer/DataLayerInformation.js
@@ -27,7 +27,7 @@ const displayFeature = properties => {
         <div key={key} className="featureRow">
           <span className="featureKey">{key}:</span>
           <span className="featureValue">
-            {displayFeature(properties[key])}
+            {properties[key] ? displayFeature(properties[key]) : 'No data'}
           </span>
         </div>
       );


### PR DESCRIPTION
We found a new situation where the GetFeatureInfo may be null and therefore crash the app. I was checking if the property were an object and if so, it recursively calls the function again. In some cases, it is an object but there is one key/value pair and the value is `null`. In this scenario, it was passing null as a parameter to the function again, then trying to get it's key/value pairs. I have now added code not to do this.

IssueID SAFB-404