### PR TITLE
SAFB-406: Disable Submitting in Comms and Missions Forms

### DIFF
--- a/src/pages/Chatbot/Comms/Components/CreateMessage.js
+++ b/src/pages/Chatbot/Comms/Components/CreateMessage.js
@@ -30,9 +30,16 @@ const CreateMessage = ({ coordinates, onCancel, setCoordinates }) => {
   const [scope, setScope] = useState('');
   const [dateRange, setDateRange] = useState(null);
   const [desc, setDesc] = useState(null);
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState({
+    coordinates: '',
+    dateRange: '',
+    desc: '',
+    scope: '',
+  });
   const [restriction, setRestriction] = useState(undefined);
   const [validCoords, isValidCoordFormat] = useState(false);
+
+  const isSubmitDisabled = !!Object.keys(errors).length;
 
   const resetState = () => {
     setScope('');
@@ -273,7 +280,12 @@ const CreateMessage = ({ coordinates, onCancel, setCoordinates }) => {
         <Button type="button" onClick={onCancel}>
           {t('cancel', { ns: 'common' })}
         </Button>
-        <Button type="button" className="mx-3" onClick={submitMsg}>
+        <Button
+          type="button"
+          className="mx-3"
+          onClick={submitMsg}
+          disabled={isSubmitDisabled}
+        >
           {t('send', { ns: 'common' })}
         </Button>
       </div>

--- a/src/pages/Chatbot/Missions/Components/CreateMission.js
+++ b/src/pages/Chatbot/Missions/Components/CreateMission.js
@@ -33,8 +33,15 @@ const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
   const [title, setTitle] = useState(null);
   const [dateRange, setDateRange] = useState(null);
   const [desc, setDesc] = useState(null);
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState({
+    coordinates: '',
+    dateRange: '',
+    desc: '',
+    title: '',
+  });
   const [validCoords, isValidCoordFormat] = useState(false);
+
+  const isSubmitDisabled = !!Object.keys(errors).length;
 
   useEffect(() => {
     dispatch(getTeamList());
@@ -273,7 +280,12 @@ const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
         <Button type="button" onClick={onCancel}>
           {t('cancel')}
         </Button>
-        <Button type="button" className="mx-3" onClick={submitMsg}>
+        <Button
+          type="button"
+          className="mx-3"
+          onClick={submitMsg}
+          disabled={isSubmitDisabled}
+        >
           {t('send')}
         </Button>
       </div>


### PR DESCRIPTION
This defaults the error object to empty strings in Comms and Missions forms.

This was done to prevent the form from being submitted before any of the fields had been touched, by using the defaulted errors keys to disable the submit button, and empty strings were used for default values to prevent any text appearing in the form when it is first loaded.

This is how it is done internally with `react-hook-form`, so simply emulating that here.

Closes #SAFB-406