### PR TITLE
Feature info

### DIFF
--- a/src/pages/DataLayer/DataLayerInformation.js
+++ b/src/pages/DataLayer/DataLayerInformation.js
@@ -287,7 +287,9 @@ const DataLayerInformationComponent = ({
                       <div>
                         <strong>Highest Value: </strong>{' '}
                         {chartValues?.length > 0
-                          ? Math.max(...chartValues.map(data => +data.y))
+                          ? Math.max(
+                              ...chartValues.map(data => +data.y),
+                            ).toFixed(2)
                           : 0}
                       </div>
                       <div>
@@ -303,7 +305,9 @@ const DataLayerInformationComponent = ({
                       <div>
                         <strong>Lowest Value: </strong>{' '}
                         {chartValues?.length > 0
-                          ? Math.min(...chartValues.map(data => +data.y))
+                          ? Math.min(
+                              ...chartValues.map(data => +data.y),
+                            ).toFixed(2)
                           : 0}
                       </div>
                       <div>


### PR DESCRIPTION
I made a stupid error when checking if the value was a number and therefore it was never rounding anything to `2 decimal places`. I have now fixed that.

During the demo, the **Timeseries GetFeatureInfo** was also shown to be inconsistent with the number of decimal places, so again, I applied the same solution to it. We could probably have a re-usable function to do this, but I wanted to keep the number of edits down, time will tell if that was the right decision or not.....