### PR TITLE
Fix People Polling in Chatbot

### DIFF
--- a/src/helpers/pollingHelper.js
+++ b/src/helpers/pollingHelper.js
@@ -76,7 +76,6 @@ const PollingHelper = props => {
       getAllNotifications({ ...notificationParams, ...dateRangeParams }),
     );
     dispatch(getAllMapRequests({ ...mapRequestParams, ...dateRangeParams }));
-    dispatch(getAllPeople({ ...dateRangeParams }, {}));
   };
 
   useEffect(() => {


### PR DESCRIPTION
The fetching of people from the Polling Helper is unneeded and causing unexpected side-effects. 

The polling inside Chatbot is unique, and handles its own polling internally, so I am removing the poll for people inside Polling Helper.