### PR TITLE
SAFB-409: Fix Reports Filtering 

### DIFF
--- a/src/store/reports/reducer.js
+++ b/src/store/reports/reducer.js
@@ -1,4 +1,5 @@
 import * as actionTypes from './types';
+import { getFilteredRec } from '../../pages/Chatbot/filter';
 import { updateObject } from '../utility';
 
 const initialState = {
@@ -63,7 +64,14 @@ const getReportsSuccess = (state, action) => {
       error: false,
     };
   } else {
+    const { sortOrder, category } = state;
+    const filteredReports = getFilteredRec(
+      action.payload.reports,
+      { category },
+      { sortOrder },
+    );
     updatedState = {
+      filteredReports,
       allReports: action.payload.reports,
       error: false,
     };


### PR DESCRIPTION
The filteredReports state (which is prioritised over allReports in the component), was not being set initially, causing the error this ticket is aimed at.

This adds the filteredReports in the same manner as the other panels, fixing the issue.

Closes SAFB-409