### PR TITLE
fix(frontend): Cannot paste WKT into form fields

### DIFF
--- a/src/components/BaseMap/MapInput.js
+++ b/src/components/BaseMap/MapInput.js
@@ -4,8 +4,6 @@ import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import { Input, Modal, ModalHeader, ModalBody } from 'reactstrap';
 
-import { getGeoFeatures } from 'store/utility';
-
 import { isWKTValid } from '../../helpers/mapHelper';
 
 const MapInput = ({
@@ -31,7 +29,7 @@ const MapInput = ({
   const onChange = val => {
     const isValid = isWKTValid(val);
     setWktStr(val);
-    isValid ? setCoordinates(getGeoFeatures(val)) : setCoordinates([]);
+    isValid ? setCoordinates(val) : setCoordinates('');
     setShowError(!isValid);
     isValidFormat(isValid);
   };

--- a/src/pages/Chatbot/Comms/Components/CreateMessage.js
+++ b/src/pages/Chatbot/Comms/Components/CreateMessage.js
@@ -8,6 +8,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Input, Button, Label, Row, Col, FormGroup } from 'reactstrap';
 import toastr from 'toastr';
 
+import { getWKTfromFeature, getGeoFeatures } from 'store/utility';
+
 import MapInput from '../../../../components/BaseMap/MapInput';
 import DateRangePicker from '../../../../components/DateRangePicker/DateRange';
 import { getError } from '../../../../helpers/errorHelper';
@@ -16,7 +18,6 @@ import {
   resetCommsResponseState,
 } from '../../../../store/comms/action';
 import 'toastr/build/toastr.min.css';
-import { getWKTfromFeature } from '../../../../store/utility';
 
 const CreateMessage = ({ coordinates, onCancel, setCoordinates }) => {
   const dispatch = useDispatch();
@@ -193,7 +194,7 @@ const CreateMessage = ({ coordinates, onCancel, setCoordinates }) => {
           placeholder={t('Map Selection', { ns: 'chatBot' })}
           rows="10"
           coordinates={getWKTfromFeature(coordinates)}
-          setCoordinates={setCoordinates}
+          setCoordinates={wkt => setCoordinates(getGeoFeatures(wkt))}
           isValidFormat={isValidCoordFormat}
           onBlur={() => {
             validateCoord();

--- a/src/pages/Chatbot/Missions/Components/CreateMission.js
+++ b/src/pages/Chatbot/Missions/Components/CreateMission.js
@@ -8,16 +8,17 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Input, Button, Row, Col, Label, FormGroup } from 'reactstrap';
 import toastr from 'toastr';
 
+import { getTeamList } from 'store/appAction';
+
 import MapInput from '../../../../components/BaseMap/MapInput';
 import DateRangePicker from '../../../../components/DateRangePicker/DateRange';
 import { getError } from '../../../../helpers/errorHelper';
-import { getTeamList } from '../../../../store/appAction';
 import {
   createMission,
   resetMissionResponseState,
 } from '../../../../store/missions/action';
 import 'toastr/build/toastr.min.css';
-import { getWKTfromFeature } from '../../../../store/utility';
+import { getGeoFeatures, getWKTfromFeature } from '../../../../store/utility';
 
 const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
   const dispatch = useDispatch();
@@ -189,7 +190,7 @@ const CreateMission = ({ t, onCancel, coordinates, setCoordinates }) => {
           placeholder={t('Map Selection', { ns: 'chatBot' })}
           rows="10"
           coordinates={getWKTfromFeature(coordinates)}
-          setCoordinates={setCoordinates}
+          setCoordinates={wkt => setCoordinates(getGeoFeatures(wkt))}
           isValidFormat={isValidCoordFormat}
           onBlur={() => {
             validateCoord();


### PR DESCRIPTION
We made a code change earlier in the week to fix pasting in WKT into the `communications` and `missions` forms. We failed to test the other forms like Fire and Burned Areas, Post Event Monitoring etc and it turns out, we broke them.

I've not reverted the code change we previously did and fixed the bug in both `communications` and `missions`.

### Testing

Go to each form:

- Create new communication
- Create new mission
- On-Demand Map Requests (do a new one for each)

This is somehting we should have caught, but were in a rush to get stuff in for the demo. Now we don't have that hanging over us, we can do proper testing....