### PR TITLE
Update key to remove warning

### DIFF
--- a/src/pages/Notifications/Components/NotificationsList.js
+++ b/src/pages/Notifications/Components/NotificationsList.js
@@ -28,7 +28,7 @@ const NotificationsList = ({
     <>
       <Row>
         {paginatedNotifications.map(alert => (
-          <NotificatonCard key={alert} card={alert} />
+          <NotificatonCard key={alert.id} card={alert} />
         ))}
       </Row>
 


### PR DESCRIPTION
The key used an object, which isn't valid for a key, instead, I've used the object's id attribute, which is unique.