### PR TITLE
Update any missing global selectors

### DIFF
--- a/src/pages/Dashboard/Components/Notifications.js
+++ b/src/pages/Dashboard/Components/Notifications.js
@@ -5,6 +5,8 @@ import { withTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 import { Container, Row } from 'reactstrap';
 
+import { defaultAoiSelector } from 'store/user/user.slice';
+
 import NotificationCard from './NotificationCard';
 
 const AreaCount = ({ t, noDataMessage, label, itemsCounts }) => {
@@ -40,7 +42,7 @@ const NotificationsBar = ({
   toggleLayerCallback,
   visibleLayers,
 }) => {
-  const defaultAOI = useSelector(state => state?.user?.defaultAoi);
+  const defaultAOI = useSelector(defaultAoiSelector);
   const nameOfAOI = defaultAOI?.features[0]?.properties?.name;
 
   return (

--- a/src/pages/Dashboard/Components/ReportBar.js
+++ b/src/pages/Dashboard/Components/ReportBar.js
@@ -6,11 +6,13 @@ import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Container, Row, Card } from 'reactstrap';
 
+import { allReportsSelector } from 'store/reports/reports.slice';
+
 import Report from '../../Chatbot/Reports/Components/Report';
 import { MAX_REPORTS } from '../constants';
 
 const ReportBar = ({ t }) => {
-  const allReports = useSelector(state => state?.reports?.allReports);
+  const allReports = useSelector(allReportsSelector);
   const truncatedReports = allReports.slice(0, MAX_REPORTS);
 
   return (

--- a/src/pages/DataLayer/index.js
+++ b/src/pages/DataLayer/index.js
@@ -37,6 +37,7 @@ import {
   isMetaDataLoadingSelector,
   timeSeriesInfoSelector,
   featureInfoSelector,
+  dataLayerMapRequestsSelector,
 } from 'store/datalayer/datalayer.slice';
 import { defaultAoiSelector } from 'store/user/user.slice';
 
@@ -69,7 +70,7 @@ const DataLayerDashboard = ({ t }) => {
   const featureInfoData = useSelector(featureInfoSelector);
 
   const dateRange = useSelector(dateRangeSelector);
-  const { allMapRequests } = useSelector(state => state?.dataLayer);
+  const allMapRequests = useSelector(dataLayerMapRequestsSelector);
 
   const [boundingBox, setBoundingBox] = useState(undefined);
   const [currentLayer, setCurrentLayer] = useState(undefined);


### PR DESCRIPTION
I found a few inline redux selectors, this is bad practice I'd say, so I've now updated them to use shared ones from the right slice. There are now no inline selectors used in any code anywhere.