### PR TITLE
Redirect to login page on Unauthorized API error

### DIFF
--- a/src/api/base.js
+++ b/src/api/base.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import storage from 'redux-persist/lib/storage/session';
 
 import { signOutSuccess } from 'store/authentication/authentication.slice';
 import { setLoading } from 'store/common/common.slice';
@@ -97,7 +98,9 @@ const handleError = (error, store) => {
     switch (error.response.status) {
       case 401:
         deleteSession();
+        storage.removeItem('persist:root');
         store.dispatch(signOutSuccess());
+        window.location.href = '/auth/sign-in';
         return Promise.reject(error);
       case 500:
         window.location.href = '/pages-500';


### PR DESCRIPTION
When the user session times out, then network requests are failing but the user still sees the protected pages. Instead, the app should redirect to landing page, where they can login again. Before this wasn't working as the code wasn't removing data in localstorage or redirecting the browser to the sign-in page, which I've added.

I'm not 100% satisfied with this, as we now delete the session and localstorage in 3 places:

* authentication slice
* Axios interceptor
* Root redux reducer

That isn't great, but for now until we re-factor this whole area, it works.

### Testing

You can log in, but you don't want to wait 1 hour for the session to expire, so instead:

1. In the Django Admin Console
2. Go to `KNOX -> Auth tokens` page
3. Find your logged in user and select it's checkbox
4. Select `Delete selected auth tokens` **Action**
5. Click **Go** button
6. Go back to the app
7. Click a link to any page, new network requests will be made and fail with `401 Not authorized` status' and therefore redirect you to the login page.

This will delete your auth token and basically invalidate your session, emulating your session timing out.