### PR TITLE
feat(frontend): remove DataType 35006 from Wildfire Simulation form

### DIFF
--- a/src/pages/DataLayer/WildfireSimulation.js
+++ b/src/pages/DataLayer/WildfireSimulation.js
@@ -172,7 +172,6 @@ const WildfireSimulation = ({
   // For this form we hard-code the list and pass along to the API
   // when we reshape the form data for submission
   const layerTypes = [
-    { id: '35006', name: 'Fire Simulation' },
     { id: '35011', name: 'Max rate of spread' },
     { id: '35010', name: 'Mean rate of spread' },
     { id: '35009', name: 'Max fireline intensity' },


### PR DESCRIPTION
DataType 35006 is no longer needed for "Wildfire Simulation" MapRequests.