### PR TITLE
feat(frontend): moved getErrorListItems out of getGeneralErrors

### DIFF
--- a/src/helpers/errorHelper.js
+++ b/src/helpers/errorHelper.js
@@ -2,27 +2,27 @@ import React from 'react';
 
 import { Card, CardBody, CardTitle, List } from 'reactstrap';
 
+const getErrorListItems = error => {
+  // turns errors into individual ListItems; an error can either
+  // be an array (of strings), or an object whose values can be
+  // arrays or strings, or jut a string.
+  if (error instanceof Object) {
+    if (error instanceof Array) {
+      return error.map(errorItem => getErrorListItems(errorItem));
+    } else {
+      return Object.entries(error).map(([key, value]) =>
+        Array.isArray(value)
+          ? value.map(valueItem => getErrorListItems(`${key} - ${valueItem}`))
+          : getErrorListItems(`${key} - ${value}`),
+      );
+    }
+  } else {
+    return <li>{error}</li>;
+  }
+};
+
 export const getGeneralErrors = errors => {
   if (!errors) return '';
-
-  const getErrorListItems = error => {
-    // turns errors into individual ListItems; an error can either
-    // be an array (of strings), or an object whose values can be
-    // arrays or strings, or jut a string.
-    if (error instanceof Object) {
-      if (error instanceof Array) {
-        return error.map(errorItem => getErrorListItems(errorItem));
-      } else {
-        return Object.entries(error).map(([key, value]) =>
-          Array.isArray(value)
-            ? value.map(valueItem => getErrorListItems(`${key} - ${valueItem}`))
-            : getErrorListItems(`${key} - ${value}`),
-        );
-      }
-    } else {
-      return <li>{error}</li>;
-    }
-  };
 
   return (
     <Card color="danger" className="text-white-50">


### PR DESCRIPTION
Moved getErrorListItems out of getGeneralErrors.  This prevents a new function being created in memory every time getGeneralErrors is run; instead the pre-existing one can just be referenced.