### PR TITLE
Don't set selected color of cluster if nothing selected

### DIFF
--- a/src/components/BaseMap/PinLayer.js
+++ b/src/components/BaseMap/PinLayer.js
@@ -120,11 +120,13 @@ export class PinLayer extends CompositeLayer {
       );
 
       // Check if the selected item is part of this clustered feature.
-      const isMatch = leaves.find(
-        leaf => leaf.properties.id === this.props.selectedItem.id,
-      );
-      if (isMatch) {
-        return SELECTED_CLUSTER;
+      if (this.props.selectedItem.id) {
+        const isMatch = leaves.find(
+          leaf => leaf.properties.id === this.props.selectedItem.id,
+        );
+        if (isMatch) {
+          return SELECTED_CLUSTER;
+        }
       }
 
       return COLOR_PRIMARY;


### PR DESCRIPTION
In some circumstances, most notably on the `Main Dashboard -> Reports` the cluster was using the selected color. This was cause I didn't first check that there is a selected item (from the side lists), in this case there never is. So the cluster definitely uses the right color.