### PR TITLE
Initialize the app the React 18 way

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import './index.scss';
@@ -21,7 +21,7 @@ setupInterceptors(store);
 // adds all shared custom validator methods to global Yup object
 extendGlobalValidators();
 
-ReactDOM.render(
+createRoot(document.getElementById('root')).render(
   <Provider store={store}>
     <PersistGate persistor={persistor}>
       <BrowserRouter>
@@ -31,7 +31,6 @@ ReactDOM.render(
       </BrowserRouter>
     </PersistGate>
   </Provider>,
-  document.getElementById('root'),
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
I missed this when I was upgrading the dependencies, but React 18 initializes an app slightly differently. You can see more at:

https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

Basically clone the branch and run the app, if you see anything of the app at all, then it has worked.