### PR TITLE
feat(frontend): prevent updating all user fields

### DIFF
--- a/src/pages/MyProfile/UpdateProfile.js
+++ b/src/pages/MyProfile/UpdateProfile.js
@@ -353,7 +353,8 @@ const UpdateProfile = ({ t }) => {
                             placeholder="organization"
                             onChange={handleChange}
                             onBlur={handleBlur}
-                            disabled={values.role === citizenId}
+                            // disabled={values.role === citizenId}
+                            disabled={true}
                             value={
                               values.role === citizenId
                                 ? ''
@@ -442,6 +443,7 @@ const UpdateProfile = ({ t }) => {
                             onChange={handleChange}
                             onBlur={handleBlur}
                             value={values.role}
+                            disabled={true}
                             data-testid="update-profile-role"
                           >
                             <option value={''}>


### PR DESCRIPTION
Prevent users from changing their own organization and role from within the dashboard.  This is already disabled in the backend.  This PR simply disables the form elements in the frontend.