### PR TITLE
feat(frontend): fix error editing events

### DIFF
--- a/src/pages/Events/Components/Tooltip.js
+++ b/src/pages/Events/Components/Tooltip.js
@@ -301,7 +301,7 @@ const Tooltip = ({
                   className="save-event-button"
                   onClick={() => {
                     setEditToggle(false);
-                    editInfo(object.id);
+                    editInfo(object.properties.id);
                   }}
                 >
                   {t('save', { ns: 'common' })}


### PR DESCRIPTION
When an event is edited in the frontend the backend returns an error b/c the event.id passed as part of the request is undefined.  This is because the events on the map are GeoJSON and therefore the id is a feature property rather than being a top-level property.